### PR TITLE
Force failure: add an unapproved Apache 2.0 dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@
 source "https://rubygems.org"
 
 gem "rake", "~> 13.0"
+gem 'addressable', '~> 2.8', '>= 2.8.4'
 

--- a/README.md
+++ b/README.md
@@ -8,5 +8,7 @@ Try running [`act`](https://github.com/nektos/act).
 
 ## Expected Behaviors
 
-The job should fail as the Apache 2.0 license isn't permitted yet.
+The `main` branch has only `MIT` dependencies which are permitted, so the build will pass.
+
+[PR #1](https://github.com/ralexander-phi/test-license_approval/pull/1) should fail as it adds a dependency with the unapproved Apache 2.0 license.
 


### PR DESCRIPTION
Leave this PR open for testing that an unapproved license on a new dependency triggers a failure.